### PR TITLE
Add imgix parameters to optimize image performance

### DIFF
--- a/src/components/Thumbs.vue
+++ b/src/components/Thumbs.vue
@@ -2,7 +2,7 @@
     <section id="thumbnails">
         <article v-for="(item, index) in items" v-bind:class="{ 'active': activeIndex == index }">
             <a class="thumbnail" v-on:click="selectImage(item, index)">
-                <img v-bind:src="item.metafield.image.imgix_url" alt="" />
+                <img v-bind:src="decorateImgixUrl(item.metafield.image.imgix_url)" alt="" />
             </a>
             <h2>{{ item.title }}</h2>
             <div v-html="item.content"></div>
@@ -45,7 +45,10 @@ export default {
         selectImage (itm, index) {
             EventBus.$emit('loaded', itm);
             this.activeIndex = index;
-        }
+        },
+        decorateImgixUrl (imgixUrl) {
+            return imgixUrl + '?auto=format,compress&w=200&dpr=2';
+        }    
     }
 }
 </script>

--- a/src/components/Viewer.vue
+++ b/src/components/Viewer.vue
@@ -9,7 +9,7 @@
                 <h2>{{ img.title }}</h2>
                 <div v-html="img.content"></div>
             </div>
-            <div class="image" v-bind:style='{ backgroundImage: "url(" + img.metafield.image.imgix_url + ")", backgroundSize: "cover",  backgroundPosition: "center" }'>
+           <div class="image" v-bind:style='{ backgroundImage: "url(" + img.metafield.image.imgix_url + "?auto=format,compress&w=2000&q=75)", backgroundSize: "cover",  backgroundPosition: "center" }'>
             </div>
         </div> 
     </div>


### PR DESCRIPTION
This change will add ?auto=format,compress&w=2000&q=75 to all background image urls viewed in the active slide.  These APIs make the following changes:

- change the format of images to webp in chrome browsers
-in none chrome browsers, the image will be examined to determine if it has transparent pixels.  If it has transparent pixels, the format will be changed to png8 (unless an animated GIF).  If there are no transparent pixels, the format will be changed to a progressive jpeg. 
- w=2000 will load a 2000 pixel wide image, which is a good size for this slider view and prevents the browser from un-necessarily loading a much wider image
-  the q=75 increases the quality to the standard quality setting.  This offsets the auto=compress parameter which lowers the quality without this API being present

This change will also add ?auto=format,compress&w=200&dpr=2 to all thumb urls.  These APIs make the following changes:

- same formatting changes above (webp, png8, pjpg)
- w=200 will load a 200 pixel wide image for all thumbnails.  Upon initially visiting this site, it will only load the initial active slide image and all 6 thumbnails.  Before this change, you would need to load all large versions of the slides.
- dpr=2 will set a higher device pixel ratio which effectively doubles the pixel density of these images.  This helps when viewed on mobile, providing a crisping look to the images when loaded on mobile devices.
